### PR TITLE
[BUGFIX] Avoid quotes around regex patterns

### DIFF
--- a/Classes/Service/KlaroService.php
+++ b/Classes/Service/KlaroService.php
@@ -451,7 +451,9 @@ class KlaroService
             } elseif (
                 is_string($value) &&
                 !str_starts_with($value, '{') &&
-                !str_starts_with($value, 'function(')
+                !str_starts_with($value, 'function(') &&
+                !str_starts_with($value, '/^') &&
+                !str_ends_with($value, '$/')
             ) {
                 $return .= '\'' . $value . '\'';
             } else {


### PR DESCRIPTION
Regex cookie patterns are handled as strings if surrounded by single quotes in klaroConfig variable.